### PR TITLE
Rename app to Devo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     # Why Mac?
     # I can't run electron playwright on ubuntu-latest and
-    # Linux support for Dyad is experimental so not as important
+    # Linux support for Devo is experimental so not as important
     # as Mac + Windows
     runs-on: macos-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,16 @@
 # Contributing
 
-Dyad is still a very early-stage project, thus the codebase is rapidly changing.
+Devo is still a very early-stage project, thus the codebase is rapidly changing.
 
-Before opening a pull request, please open an issue and discuss whether the change makes sense in Dyad. Ensuring a cohesive user experience sometimes means we can't include every possible feature or we need to consider the long-term design of how we want to support a feature area.
+Before opening a pull request, please open an issue and discuss whether the change makes sense in Devo. Ensuring a cohesive user experience sometimes means we can't include every possible feature or we need to consider the long-term design of how we want to support a feature area.
 
 ## More than code contributions
 
-Something that I really appreciate are all the non-code contributions, such as reporting bugs, writing feature requests and participating on [Dyad's sub-reddit](https://www.reddit.com/r/dyadbuilders).
+Something that I really appreciate are all the non-code contributions, such as reporting bugs, writing feature requests and participating on [Devo's sub-reddit](https://www.reddit.com/r/dyadbuilders).
 
 ## Development
 
-Dyad is an Electron app.
+Devo is an Electron app.
 
 **Install dependencies:**
 

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 Dyad Tech, Inc.
+   Copyright 2025 Devo Tech, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# dyad
+# devo
 
-Dyad is a local, open-source AI app builder. It's fast, private and fully under your control — like Lovable, v0, or Bolt, but running right on your machine.
+Devo is a local, open-source AI app builder. It's fast, private and fully under your control — like Lovable, v0, or Bolt, but running right on your machine.
 
 ![Image](https://github.com/user-attachments/assets/f6c83dfc-6ffd-4d32-93dd-4b9c46d17790)
 
-More info at: [http://dyad.sh/](http://dyad.sh/)
+More info at: [http://devo.sh/](http://devo.sh/)
 
 ## 🚀 Features
 
@@ -16,8 +16,8 @@ More info at: [http://dyad.sh/](http://dyad.sh/)
 
 No sign-up required. Just download and go.
 
-### [👉 Download for your platform](https://www.dyad.sh/#download)
+### [👉 Download for your platform](https://www.devo.sh/#download)
 
-**dyad** is open source (Apache 2.0-licensed).
+**devo** is open source (Apache 2.0-licensed).
 
-If you're interested in contributing to dyad, please read our [contributing](./CONTRIBUTING.md) doc.
+If you're interested in contributing to devo, please read our [contributing](./CONTRIBUTING.md) doc.

--- a/e2e-tests/main.spec.ts
+++ b/e2e-tests/main.spec.ts
@@ -44,7 +44,7 @@ test.beforeAll(async () => {
     args: [
       appInfo.main,
       "--enable-logging",
-      "--user-data-dir=/tmp/dyad-e2e-tests",
+      "--user-data-dir=/tmp/devo-e2e-tests",
     ],
     executablePath: appInfo.executable,
   });

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -53,8 +53,8 @@ const config: ForgeConfig = {
   packagerConfig: {
     protocols: [
       {
-        name: "Dyad",
-        schemes: ["dyad"],
+        name: "Devo",
+        schemes: ["devo"],
       },
     ],
     icon: "./assets/icon/logo",
@@ -87,7 +87,7 @@ const config: ForgeConfig = {
     new MakerRpm({}),
     new MakerDeb({
       options: {
-        mimeType: ["x-scheme-handler/dyad"],
+        mimeType: ["x-scheme-handler/devo"],
       },
     }),
   ],

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Dyad</title>
+    <title>Devo</title>
     <link href="/src/styles/globals.css" rel="stylesheet" />
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dyad",
+  "name": "devo",
   "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dyad",
+      "name": "devo",
       "version": "0.6.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "dyad",
-  "productName": "dyad",
+  "name": "devo",
+  "productName": "devo",
   "version": "0.7.0",
   "description": "My Electron application description",
   "main": ".vite/build/main.js",

--- a/scaffold/index.html
+++ b/scaffold/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>dyad-generated-app</title>
+    <title>devo-generated-app</title>
   </head>
 
   <body>

--- a/scaffold/src/components/made-with-devo.tsx
+++ b/scaffold/src/components/made-with-devo.tsx
@@ -1,13 +1,13 @@
-export const MadeWithDyad = () => {
+export const MadeWithDevo = () => {
   return (
     <div className="p-4 text-center">
       <a
-        href="https://www.dyad.sh/"
+        href="https://www.devo.sh/"
         target="_blank"
         rel="noopener noreferrer"
         className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
       >
-        Made with Dyad
+        Made with Devo
       </a>
     </div>
   );

--- a/scaffold/src/pages/Index.tsx
+++ b/scaffold/src/pages/Index.tsx
@@ -1,6 +1,6 @@
 // Update this page (the content is just a fallback if you fail to update the page)
 
-import { MadeWithDyad } from "@/components/made-with-dyad";
+import { MadeWithDevo } from "@/components/made-with-devo";
 
 const Index = () => {
   return (
@@ -11,7 +11,7 @@ const Index = () => {
           Start building your amazing project here!
         </p>
       </div>
-      <MadeWithDyad />
+      <MadeWithDevo />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- rename app from Dyad to Devo across documentation and config
- update HTML titles and scaffold content
- adjust forge protocol names and e2e paths for new name

## Testing
- `npm test` *(fails: vitest not found)*